### PR TITLE
Adds CORS support and updates middleware configuration

### DIFF
--- a/first_project/settings.py
+++ b/first_project/settings.py
@@ -40,13 +40,25 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    # 'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+CSRF_TRUSTED_ORIGINS = [
+    'http://127.0.0.1:5500',
+    'http://localhost:5500',
+]
+
+
+CORS_ALLOWED_ORIGINS = [
+    'http://127.0.0.1:5500',
+    'http://localhost:5500',
 ]
 
 ROOT_URLCONF = 'first_project.urls'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 asgiref==3.9.1
 Django==5.2.6
+django-cors-headers==4.7.0
 sqlparse==0.5.3
 tzdata==2025.2


### PR DESCRIPTION
Integrates `django-cors-headers` to allow cross-origin requests from local development origins. Adds `CorsMiddleware` to the middleware stack and comments out the CSRF middleware. Configures trusted origins and allowed CORS origins for `localhost` and `127.0.0.1:5500`.

Updates `requirements.txt` to include `django-cors-headers` dependency.